### PR TITLE
Make a utility method to wait for side effects in tests

### DIFF
--- a/python/tests/utils/__init__.py
+++ b/python/tests/utils/__init__.py
@@ -5,6 +5,7 @@ import tempfile
 import shutil
 
 import decorator
+import time
 
 """
 Swiped from
@@ -57,3 +58,23 @@ def tmp(path=None, teardown=True):
         except OSError as oserr:
             logging.debug('tmp:rmtree failed %s (%s)' % (fname, oserr))
             shutil.rmtree(fname, ignore_errors=True)
+
+def wait_until(func, interval=0.5, timeout=30):
+    """Expects 'func' to raise an AssertionError to indicate failure.
+    Repeatedly calls 'func' until it does not throw an AssertionError.
+    Waits 'interval' seconds before each invocation. If 'timeout' is
+    reached, will raise the AssertionError.
+
+    Example of how to wait for a file to be created:
+
+    wait_until(lambda: assertFileExists("/some/file"))"""
+    t = 0
+    while True:
+        time.sleep(interval)
+        t += interval
+        try:
+            func()
+            return
+        except AssertionError:
+            if t >= timeout:
+                raise


### PR DESCRIPTION
Was having some trouble with a test timing out.

In stead of simply increasing the timeout slightly, it might be a good idea to in general loop until desired side effect is seen, with a longer default timeout. In that way one does not have to compromise between wanting tests to finish quickly, and ensuring they don't fail arbitrarily because machine resources are unavailable.

Created here a function 'wait_until' intended to be used in all such cases where a test needs to wait for a side effect.

PS. Was originally a pull request for master. Since this has been fixed in this refactor_job_dispatch branch already, I create this pull request to merge it here first, to avoid lots of conflicts later.